### PR TITLE
build: add "--frozen-lockfile" to "yarn install"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 # Update dependencies
 setup			:; make update-libs ; make install-deps
 update-libs		:; git submodule update --init --recursive
-install-deps	:; yarn install
+install-deps	:; yarn install --frozen-lockfile
 
 # Build & test & deploy
 build         	:; forge build


### PR DESCRIPTION
Add a new flag [`--frozen-lockfile`](https://classic.yarnpkg.com/en/docs/cli/install#toc-yarn-install-frozen-lockfile) to the `yarn install` command.

The benefit of using this is that it ensures that there is no update to the state of the node dependencies in CI - users must ensure parity between their local environments and CI if they want the workflows to work.