### PR TITLE
ci: remove superfluous yarn installation step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,14 +16,14 @@ jobs:
 
       - name: Install node
         uses: actions/setup-node@v2
+        with:
+          cache: yarn
+          node-version: 16
 
       - name: Clone repo with submodules
         uses: actions/checkout@v2
         with:
           submodules: recursive
-
-      - name: Install yarn
-        run: npm i -g yarn
 
       - name: Install dependencies
         run: make


### PR DESCRIPTION
First, this PR removes the superfluous yarn installation step from the CI workflow. The [setup-node](https://github.com/actions/setup-node) action automatically installs npm and yarn globally.

Second, this PR activates the [caching functionality](https://github.com/actions/setup-node#caching-packages-dependencies) of the `setup-node` GitHub Action by setting the `cache` field.